### PR TITLE
Add ecdsa secp384r1

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -47,6 +47,7 @@ const ContentType = @import("content.zig").ContentType;
 const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const P256 = std.crypto.sign.ecdsa.EcdsaP256Sha256;
+const P384 = std.crypto.sign.ecdsa.EcdsaP384Sha384;
 
 const rsa = @import("rsa.zig");
 
@@ -207,6 +208,7 @@ pub fn TLSClientImpl(comptime ReaderType: type, comptime WriterType: type, compt
             try res.cipher_suites.append(.TLS_CHACHA20_POLY1305_SHA256);
 
             try res.signature_schems.append(.ecdsa_secp256r1_sha256);
+            try res.signature_schems.append(.ecdsa_secp384r1_sha384);
             try res.signature_schems.append(.rsa_pss_rsae_sha256);
 
             return res;
@@ -813,7 +815,7 @@ pub fn TLSClientImpl(comptime ReaderType: type, comptime WriterType: type, compt
                 }
 
                 const pubkey = c.cert.tbs_certificate.subjectPublicKeyInfo.publicKey;
-                if (pubkey == .secp256r1 or pubkey == .rsa) {
+                if (pubkey == .secp256r1 or pubkey == .secp384r1 or pubkey == .rsa) {
                     try self.cert_pubkeys.append(try pubkey.copy(self.allocator));
                 } else {
                     return Error.UnsupportedCertificateAlgorithm;
@@ -847,6 +849,11 @@ pub fn TLSClientImpl(comptime ReaderType: type, comptime WriterType: type, compt
                 .ecdsa_secp256r1_sha256 => {
                     const pk = (try self.getPublicKey(.secp256r1)).secp256r1;
                     const sig = try P256.Signature.fromDer(cert_verify.signature);
+                    try sig.verify(verify_stream.getWritten(), pk.key);
+                },
+                .ecdsa_secp384r1_sha384 => {
+                    const pk = (try self.getPublicKey(.secp384r1)).secp384r1;
+                    const sig = try P384.Signature.fromDer(cert_verify.signature);
                     try sig.verify(verify_stream.getWritten(), pk.key);
                 },
                 .rsa_pss_rsae_sha256 => {
@@ -1269,6 +1276,10 @@ test "connect e2e with x25519" {
 
     tls_client.key_shares.clearAndFree();
     try tls_client.key_shares.append(.x25519);
+
+    tls_client.signature_schems.clearAndFree();
+    try tls_client.signature_schems.append(.ecdsa_secp256r1_sha256);
+    try tls_client.signature_schems.append(.rsa_pss_rsae_sha256);
 
     try tls_client.connect("localhost", 443);
     try expect(std.mem.eql(u8, &client_ans, test_send_stream.getWritten()));


### PR DESCRIPTION
Could not connect to the public tls endpoint (connect.ngs.global) without secp384r1 certificate algorithm.

Added support for the star certificate. This one has certificate for *.ngs.global, so exact matching didn't work.

